### PR TITLE
auto_index fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ If root is a file, serve only root file.
 ## `auto_index`
 
     # Mojolicious::Lite
-    plugin Directory => { auto_index => 0 };
+    plugin 'Directory::Stylish' => { auto_index => 0 };
 
 Automatically generate index page for directory, default true.
 

--- a/lib/Mojolicious/Plugin/Directory/Stylish.pm
+++ b/lib/Mojolicious/Plugin/Directory/Stylish.pm
@@ -20,6 +20,7 @@ sub register {
     my $handler     = $args->{handler};
     my $index       = $args->{dir_index};
     my $enable_json = $args->{enable_json};
+    my $auto_index  = $args->{auto_index} // 1;
 
     my $css         = $args->{css} || 'style';
     my $render_opts = $args->{render_opts} || {};
@@ -46,7 +47,7 @@ sub register {
 
                 $c->stash(css => $css),
                 render_indexes( $c, $path, $render_opts, $enable_json )
-                    unless ( $c->tx->res->code );
+                    unless not $auto_index or ( $c->tx->res->code );
             }
         },
     );

--- a/lib/Mojolicious/Plugin/Directory/Stylish.pm
+++ b/lib/Mojolicious/Plugin/Directory/Stylish.pm
@@ -179,7 +179,7 @@ If root is a file, serve only root file.
 =head2 C<auto_index>
 
   # Mojolicious::Lite
-  plugin Directory => { auto_index => 0 };
+  plugin 'Directory::Stylish' => { auto_index => 0 };
 
 Automatically generate index page for directory, default true.
 

--- a/t/auto_index.t
+++ b/t/auto_index.t
@@ -7,7 +7,7 @@ use Test::Mojo;
 use File::Basename;
 
 my $dir = dirname(__FILE__);
-plugin 'Directory', root => $dir, auto_index => 0;
+plugin 'Directory::Stylish', root => $dir, auto_index => 0;
 
 my $t = Test::Mojo->new();
 


### PR DESCRIPTION
t/auto_index.t was testing parent module and worked/failed based on presence of Mojolicious::Plugin::Directory. Also auto_index setting wasn't honored.
